### PR TITLE
Implement time ranges for specific collections

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
 FROM alpine:latest
 
-RUN --mount=type=cache,target=/etc/apk/cache apk add --update-cache curl bash mongodb-tools minio-client
+RUN --mount=type=cache,target=/etc/apk/cache apk add --update-cache curl bash mongodb-tools minio-client python3
 
 COPY scripts/backup-mongodb.sh /usr/local/bin/backup-mongodb.sh
 RUN chmod +x /usr/local/bin/backup-mongodb.sh
+
+COPY scripts/query-generator.py /usr/local/bin/query-generator.py
 
 ENV MINIO_COMMAND="mcli"
 CMD ["/usr/local/bin/backup-mongodb.sh"]

--- a/README.md
+++ b/README.md
@@ -24,7 +24,23 @@ MONGODB_READ_PREFERENCE='secondaryPreferred'
 RETENTION_PERIOD='7d'
 MINIO_COMMAND='mc'
 DISCORD_WEBHOOK_URL=''
+COLLECTION_STRATEGIES='db.collection1=day db.collection2=week db.collection3=month'
+STRATEGY_ID='_id'
 ```
+
+## Strategies
+The script supports different backup strategies for creating partial backups of specific collections.
+If no strategies are defined, a full dump of the mongodb instance will be created (all databases and collections).
+
+The strategies are defined in the `COLLECTION_STRATEGIES` environment variable as a space-separated list of `db.collection=strategy` pairs.
+Supported strategies:
+- `full`: full backup of the collection
+- `day`: [yesterday 00:00, today 00:00)
+- `week`: [1st day of last week 00:00, 1st day of this week 00:00)
+- `month`: [1st day of last month 00:00, 1st day of this month 00:00)
+
+The `STRATEGY_ID` variable defines the field used for filtering the documents in the collection (default is `_id`).
+This can be changed if a collection references another object which should be used as the filter field (e.g. `_parent`).
 
 ## Cron backup with kubernetes
 

--- a/README.md
+++ b/README.md
@@ -24,22 +24,23 @@ MONGODB_READ_PREFERENCE='secondaryPreferred'
 RETENTION_PERIOD='7d'
 MINIO_COMMAND='mc'
 DISCORD_WEBHOOK_URL=''
-COLLECTION_STRATEGIES='db.collection1=day db.collection2=week db.collection3=month'
-STRATEGY_ID='_id'
+COLLECTIONS='db.collection1:day:_parent db.collection2:month db.collection3'
 ```
 
 ## Strategies
 The script supports different backup strategies for creating partial backups of specific collections.
-If no strategies are defined, a full dump of the mongodb instance will be created (all databases and collections).
+If no collections are defined, a full dump of the mongodb instance will be created (all databases and collections).
 
-The strategies are defined in the `COLLECTION_STRATEGIES` environment variable as a space-separated list of `db.collection=strategy` pairs.
+The strategies are defined in the `COLLECTIONS` environment variable as a space-separated list of `db.collection:STRATEGY:FIELD` pairs.
+Both `:FIELD` and `:STRATEGY` are optional and will default to `full` and `_id` respectively.
+
 Supported strategies:
 - `full`: full backup of the collection
 - `day`: [yesterday 00:00, today 00:00)
 - `week`: [Monday of last week 00:00, Monday of this week 00:00)
 - `month`: [1st day of last month 00:00, 1st day of this month 00:00)
 
-The `STRATEGY_ID` variable defines the field used for filtering the documents in the collection (default is `_id`).
+The `FIELD` defines the field used for filtering the documents in the collection (default is `_id`).
 This can be changed if a collection references another object which should be used as the filter field (e.g. `_parent`).
 
 ## Cron backup with kubernetes

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ The strategies are defined in the `COLLECTION_STRATEGIES` environment variable a
 Supported strategies:
 - `full`: full backup of the collection
 - `day`: [yesterday 00:00, today 00:00)
-- `week`: [1st day of last week 00:00, 1st day of this week 00:00)
+- `week`: [Monday of last week 00:00, Monday of this week 00:00)
 - `month`: [1st day of last month 00:00, 1st day of this month 00:00)
 
 The `STRATEGY_ID` variable defines the field used for filtering the documents in the collection (default is `_id`).

--- a/scripts/backup-mongodb.sh
+++ b/scripts/backup-mongodb.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 # Required environment variables
@@ -56,6 +56,11 @@ else
     COLLECTION="${DATABASE_COLLECTION#*.}" # Remove everything before first .
 
     echo "[mongodb-backup] Processing collection '$DATABASE.$COLLECTION' with strategy '$STRATEGY'..."
+    if [ "${STRATEGY^^}" != "FULL" ]; then
+      QUERY=$(python3 /usr/local/bin/query-generator.py "$STRATEGY" "$STRATEGY_ID")
+    else
+      QUERY=""
+    fi
 
     mongodump --archive --gzip --readPreference=$MONGODB_READ_PREFERENCE --uri "$MONGODB_URI" --db "$DATABASE" --collection "$COLLECTION" --query "$QUERY" | \
     $MINIO_COMMAND pipe "storage/$MINIO_BUCKET/$MINIO_PATH/${COLLECTION}_$NOW.bson.gz"

--- a/scripts/backup-mongodb.sh
+++ b/scripts/backup-mongodb.sh
@@ -49,10 +49,11 @@ else
   for COLLECTION_STRATEGY in $COLLECTION_STRATEGIES; do
     [ -z "$COLLECTION_STRATEGY" ] && continue # Skip empty entries
 
-    STRATEGY="${COLLECTION_STRATEGY#*=}"
-    DATABASE_COLLECTION="${COLLECTION_STRATEGY%%=*}"
-    DATABASE="${DATABASE_COLLECTION%%.*}"
-    COLLECTION="${DATABASE_COLLECTION#*.}"
+    # db.coll.ection=strategy
+    STRATEGY="${COLLECTION_STRATEGY#*=}" # Remove everything before =
+    DATABASE_COLLECTION="${COLLECTION_STRATEGY%%=*}" # Remove everything after =
+    DATABASE="${DATABASE_COLLECTION%%.*}" # Remove everything after first .
+    COLLECTION="${DATABASE_COLLECTION#*.}" # Remove everything before first .
 
     echo "[mongodb-backup] Processing collection '$DATABASE.$COLLECTION' with strategy '$STRATEGY'..."
 

--- a/scripts/query-generator.py
+++ b/scripts/query-generator.py
@@ -1,0 +1,62 @@
+import json
+from datetime import datetime, timedelta, timezone
+
+
+def date_to_epoch_seconds(date) -> int:
+    return int(date.timestamp())
+
+
+def epoch_to_oid(epoch_seconds) -> str:
+    return hex(epoch_seconds)[2:] + "0000000000000000"
+
+
+def strategy_to_query(strategy, field) -> str:
+    if strategy == "DAY":
+        # yesterday 00:00 - today 00:00
+        start_date = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0) - timedelta(days=1)
+        end_date = datetime.now(timezone.utc).replace(hour=0, minute=0, second=0, microsecond=0)
+    elif strategy == "WEEK":
+        # last week Monday 00:00 - this week Monday 00:00
+        start_date = (datetime.now(timezone.utc) - timedelta(days=datetime.now(timezone.utc).weekday() + 7)).replace(hour=0, minute=0, second=0, microsecond=0)
+        end_date = (datetime.now(timezone.utc) - timedelta(days=datetime.now(timezone.utc).weekday())).replace(hour=0, minute=0, second=0, microsecond=0)
+    elif strategy == "MONTH":
+        # last month 1st 00:00 - this month 1st 00:00
+        first_of_this_month = datetime.now(timezone.utc).replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        last_of_last_month = first_of_this_month - timedelta(days=1)
+        start_date = last_of_last_month.replace(day=1, hour=0, minute=0, second=0, microsecond=0)
+        end_date = first_of_this_month
+    else:
+        raise ValueError('Supported: DAY, WEEK, MONTH')
+
+    start_epoch = date_to_epoch_seconds(start_date)
+    end_epoch = date_to_epoch_seconds(end_date)
+
+    start_oid = epoch_to_oid(start_epoch)
+    end_oid = epoch_to_oid(end_epoch)
+
+    return json.dumps({
+        field: {
+            "$gte": {"$oid": start_oid},
+            "$lt": {"$oid": end_oid}
+        }
+    })
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) != 3:
+        print("Usage: python query-generator.py <DAY|WEEK|MONTH> <field>")
+        sys.exit(1)
+
+    strategy = sys.argv[1].upper()
+    if strategy == 'FULL':
+        print("")
+        sys.exit(0)
+
+    field = sys.argv[2]
+
+    try:
+        print(strategy_to_query(strategy, field))
+    except ValueError as e:
+        sys.exit(1)

--- a/scripts/query-generator.py
+++ b/scripts/query-generator.py
@@ -50,10 +50,6 @@ if __name__ == "__main__":
         sys.exit(1)
 
     strategy = sys.argv[1].upper()
-    if strategy == 'FULL':
-        print("")
-        sys.exit(0)
-
     field = sys.argv[2]
 
     try:

--- a/scripts/query-generator.py
+++ b/scripts/query-generator.py
@@ -59,4 +59,5 @@ if __name__ == "__main__":
     try:
         print(strategy_to_query(strategy, field))
     except ValueError as e:
+        print(e, file=sys.stderr)
         sys.exit(1)


### PR DESCRIPTION
The script now supports different backup strategies for creating partial backups of specific collections.
If no strategies are defined, a full dump of the mongodb instance will be created (all databases and collections).

The strategies are defined in the `COLLECTION_STRATEGIES` environment variable as a space-separated list of `db.collection=strategy` pairs.
Supported strategies:
- `full`: full backup of the collection
- `day`: [yesterday 00:00, today 00:00)
- `week`: [1st day of last week 00:00, 1st day of this week 00:00)
- `month`: [1st day of last month 00:00, 1st day of this month 00:00)

The `STRATEGY_ID` variable defines the field used for filtering the documents in the collection (default is `_id`).
This can be changed if a collection references another object which should be used as the filter field (e.g. `_parent`).

The full dump will be named `mongodump_<date>.bson.gz` while the collections will be named `db.collection_<date>.bson.gz`

Fixes #2 