### PR TITLE
Print output to console

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 WORKDIR /app
 
 
-ENV UV_LOCKED=1 UV_NO_SYNC=1 UV_NO_DEV=1
+ENV UV_LOCKED=1 UV_NO_SYNC=1 UV_NO_DEV=1 PYTHONUNBUFFERED=1
 # See https://docs.astral.sh/uv/guides/integration/docker/#intermediate-layers
 RUN --mount=type=cache,id=uv,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \

--- a/backup_mongodb_s3/mongodump.py
+++ b/backup_mongodb_s3/mongodump.py
@@ -1,6 +1,6 @@
 import subprocess
+
 from minio import Minio
-from backup_mongodb_s3 import config
 
 
 def mongodump_to_minio_stream(
@@ -29,7 +29,7 @@ def mongodump_to_minio_stream(
     process = subprocess.Popen(
         command,
         stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
+        stderr=None,
         bufsize=1024 * 1024,
     )
 
@@ -46,10 +46,9 @@ def mongodump_to_minio_stream(
             content_type="application/gzip",
         )
 
-        _, stderr = process.communicate()
-
-        if process.returncode != 0:
-            raise RuntimeError(stderr.decode("utf-8", errors="replace"))
+        returncode = process.wait()
+        if returncode != 0:
+            raise RuntimeError(f"mongodump failed with exit code {returncode}")
 
     finally:
         process.kill()


### PR DESCRIPTION
- Use PYTHONUNBUFFERED env variable
- Print mongodump's output to console


## Example using Docker
```
Attaching to backup-mongodb-s3-1
backup-mongodb-s3-1  | [mongodb-backup] Executing backup for backup.persons with strategy 'FULL'...
backup-mongodb-s3-1  | 2026-07-20T07:35:37.177+0000     writing backup.persons to archive on stdout
backup-mongodb-s3-1  | 2026-07-20T07:35:37.183+0000     done dumping backup.persons (70 documents)
backup-mongodb-s3-1  | [mongodb-backup] Backup for 'backup.persons' completed successfully.
backup-mongodb-s3-1  | [mongodb-backup] Deleted old backup: backups/backup_persons_FULL_2026-07-20_07-19-52.bson.gz
backup-mongodb-s3-1 exited with code 0   
```

Fixes #8 