### PR TITLE
Backup entire database by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,14 @@ A year is considered as 365 days and a month is considered as 30 days.
 
 To disable this feature, leave `RETENTION_PERIOD` empty.
 
-`MONGODB_COLLECTIONS` can be used to specify the tables to back up (see [Backup Settings](#backup-settings)).
+`MONGODB_COLLECTIONS` can be used to specify the collections to back up (see [Backup Settings](#backup-settings)).
 
-Backups will be stored under the specified `MINIO_PATH` in the bucket `MINIO_BUCKET`, with filenames in the format `<database>_<collection>_<strategy>_<date>.<extension>`.
+Backups will be stored under the specified `MINIO_PATH` in the bucket `MINIO_BUCKET`, with filenames in the format `<database>_<collection>_<strategy>_<date>.bson.gz`.
 The `date` will depend on the strategy and include the timestamp of the backup (for `FULL` strategy) or the start date of the backup (for other strategies).
 If the whole database is backed up, the collection will be omitted from the filename.
+
+If no collections/databases are specified, the database specified in the `MONGODB_URI` will be backed up.
+The filename will be `backup_FULL_<date>.bson.gz`.
 
 When setting `DISCORD_WEBHOOK_URL`, a notification will be sent to the specified Discord webhook if the backup fails.
 

--- a/backup_mongodb_s3/backup.py
+++ b/backup_mongodb_s3/backup.py
@@ -103,9 +103,7 @@ def main() -> None:
             sys.exit(1)
 
         if not config.MONGODB_COLLECTIONS.strip():
-            print("[mongodb-backup] No databases/collections specified for backup.", file=sys.stderr)
-            utils.webhook("Backup process stopped due to missing collections configuration.")
-            sys.exit(0)
+            print("[mongodb-backup] No databases/collections specified for backup. Assuming database is set using MONGODB_URI...")
 
         # Create Minio Client
         try:
@@ -138,46 +136,62 @@ def main() -> None:
             sys.exit(1)
 
         # Load collection configuration
-        try:
-            entries = yaml.safe_load(config.MONGODB_COLLECTIONS)
-            if not isinstance(entries, list):
-                raise ValueError("Must be a YAML array of collection entries.")
-        except Exception as e:
-            print(f"[mongodb-backup] Failed to parse collections: {e}", file=sys.stderr)
-            utils.webhook("Backup process failed due to invalid collection configuration.")
-            sys.exit(1)
+        if config.MONGODB_COLLECTIONS.strip():
+            try:
+                entries = yaml.safe_load(config.MONGODB_COLLECTIONS)
+                if not isinstance(entries, list):
+                    raise ValueError("Must be a YAML array of collection entries.")
+            except Exception as e:
+                print(f"[mongodb-backup] Failed to parse collections: {e}", file=sys.stderr)
+                utils.webhook("Backup process failed due to invalid collection configuration.")
+                sys.exit(1)
 
-        # Check if collections are valid and exist
-        if not check_entries(mongo, entries):
-            utils.webhook("Backup process failed due to invalid collection configuration.") # Webhook is enough, prints are done in check_entries
-            sys.exit(1)
+            # Check if collections are valid and exist
+            if not check_entries(mongo, entries):
+                utils.webhook("Backup process failed due to invalid collection configuration.") # Webhook is enough, prints are done in check_entries
+                sys.exit(1)
 
-        # Go through all entries
-        for entry in entries:
+            # Go through all entries
+            for entry in entries:
 
-            # Get settings from entry
-            database, collection, strategy, ts_column, ts_format = extract_settings(entry)
+                # Get settings from entry
+                database, collection, strategy, ts_column, ts_format = extract_settings(entry)
 
-            # Generate query (at this point, the settings are checked, so we can cast without issues)
-            filename, bounds = strategy_to_query(cast(Strategy, strategy), database, collection, ts_column, cast(TimeStampFormat, ts_format))
+                # Generate query (at this point, the settings are checked, so we can cast without issues)
+                filename, bounds = strategy_to_query(cast(Strategy, strategy), database, collection, ts_column, cast(TimeStampFormat, ts_format))
 
-            # Execute backup
-            backup_name = f"{database}.{collection}" if collection else database
-            print(f"[mongodb-backup] Executing backup for {backup_name} with strategy '{strategy}'...")
+                # Execute backup
+                backup_name = f"{database}.{collection}" if collection else database
+                print(f"[mongodb-backup] Executing backup for {backup_name} with strategy '{strategy}'...")
+                try:
+                    mongodump_to_minio_stream(
+                        minio_client=minio,
+                        minio_bucket=config.MINIO_BUCKET,
+                        minio_file_name=f"{config.MINIO_PATH}/{filename}",
+                        mongo_uri=config.MONGODB_URI,
+                        mongo_database=database,
+                        mongo_collection=collection if collection else None,
+                        mongo_query=json.dumps(bounds, default=json_util.default) if bounds else None
+                    )
+                    print(f"[mongodb-backup] Backup for '{backup_name}' completed successfully.")
+                except Exception as e:
+                    print(f"[mongodb-backup] Backup for collection '{backup_name}' failed with error: {e}", file=sys.stderr)
+                    utils.webhook(f"Backup of MongoDB collection `{backup_name}` failed.")
+                    sys.exit(1)
+        else:
+            timestamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%d_%H-%M-%S")
+            filename = "backup_FULL_" + timestamp + ".bson.gz"
             try:
                 mongodump_to_minio_stream(
                     minio_client=minio,
                     minio_bucket=config.MINIO_BUCKET,
                     minio_file_name=f"{config.MINIO_PATH}/{filename}",
                     mongo_uri=config.MONGODB_URI,
-                    mongo_database=database,
-                    mongo_collection=collection if collection else None,
-                    mongo_query=json.dumps(bounds, default=json_util.default) if bounds else None
                 )
-                print(f"[mongodb-backup] Backup for '{backup_name}' completed successfully.")
+                print(f"[mongodb-backup] Backup for whole database completed successfully.")
             except Exception as e:
-                print(f"[mongodb-backup] Backup for collection '{backup_name}' failed with error: {e}", file=sys.stderr)
-                utils.webhook(f"Backup of MongoDB collection `{backup_name}` failed.")
+                print(f"[mongodb-backup] Backup for whole database failed with error: {e}", file=sys.stderr)
+                utils.webhook(f"Backup of whole MongoDB database failed.")
                 sys.exit(1)
 
         if config.RETENTION_PERIOD.strip():

--- a/backup_mongodb_s3/mongodump.py
+++ b/backup_mongodb_s3/mongodump.py
@@ -8,7 +8,7 @@ def mongodump_to_minio_stream(
         minio_bucket: str,
         minio_file_name: str,
         mongo_uri: str,
-        mongo_database: str,
+        mongo_database: str | None = None,
         mongo_collection: str | None = None,
         mongo_query: str | None = None,
 ):
@@ -17,8 +17,10 @@ def mongodump_to_minio_stream(
         "--archive",
         "--gzip",
         "--uri", mongo_uri,
-        "--db", mongo_database,
     ]
+
+    if mongo_database:
+        command += ["--db", mongo_database]
 
     if mongo_collection:
         command += ["--collection", mongo_collection]


### PR DESCRIPTION
- If `MONGODB_COLLECTIONS` is unset, backup the entire database (mongodump default behavior)
- Name of the file will be `backup_FULL_<date>.bson.gz`

```
Attaching to backup-mongodb-s3-1
backup-mongodb-s3-1  | [mongodb-backup] No databases/collections specified for backup. Assuming database is set using MONGODB_URI...
backup-mongodb-s3-1  | [mongodb-backup] Backup for whole database completed successfully.
backup-mongodb-s3-1  | [mongodb-backup] Deleted old backup: backups/backup_FULL_2026-07-20_08-15-49.bson.gz
backup-mongodb-s3-1  | [mongodb-backup] Deleted old backup: backups/backup_FULL_2026-07-20_08-20-02.bson.gz
backup-mongodb-s3-1  | [mongodb-backup] Deleted old backup: backups/backup_persons_FULL_2026-07-20_08-20-02.bson.gz
backup-mongodb-s3-1 exited with code 0               
```

<img width="358" height="40" alt="image" src="https://github.com/user-attachments/assets/d6466837-848d-44d4-823a-ac92b2c6f73b" />

```
$ mongorestore -u root -p password --gzip --archive=backup_FULL_2026-07-20_09-02-49.bson.gz
2026-07-20T11:04:33.466+0200	preparing collections to restore from
2026-07-20T11:04:33.478+0200	reading metadata for `backup.persons` from "archive `backup_FULL_2026-07-20_09-02-49.bson.gz`"
2026-07-20T11:04:33.511+0200	restoring `backup.persons` from "archive `backup_FULL_2026-07-20_09-02-49.bson.gz`"
2026-07-20T11:04:33.522+0200	finished restoring `backup.persons` (70 documents, 0 failures)
2026-07-20T11:04:33.522+0200	restoring users from "archive `backup_FULL_2026-07-20_09-02-49.bson.gz`"
2026-07-20T11:04:33.552+0200	restoring indexes for collection `backup.persons` from metadata
2026-07-20T11:04:33.552+0200	index: &idx.IndexDocument{Options:bson.M{"name":"created_at_dt_1", "v":2}, Key:bson.D{bson.E{Key:"created_at_dt", Value:1}}, PartialFilterExpression:(*bson.D)(nil)}
2026-07-20T11:04:33.552+0200	index: &idx.IndexDocument{Options:bson.M{"name":"created_at_epoch_1", "v":2}, Key:bson.D{bson.E{Key:"created_at_epoch", Value:1}}, PartialFilterExpression:(*bson.D)(nil)}
2026-07-20T11:04:33.608+0200	70 document(s) restored successfully. 0 document(s) failed to restore.
```

Fixes #7 